### PR TITLE
Create a staging directory on the Salt Master

### DIFF
--- a/roles/saltmaster/staging/init.sls
+++ b/roles/saltmaster/staging/init.sls
@@ -1,0 +1,20 @@
+#   -------------------------------------------------------------
+#   Salt — Staging directory for ops
+#   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#   Project:        Woods Cloud
+#   Created:        2017-09-25
+#   License:        Trivial work, not eligible to copyright
+#   -------------------------------------------------------------
+
+staging_repo:
+  file.directory:
+    - name: /opt/woodscloud-operations
+    - user: deploy
+    - group: deploy
+    - dir_mode: 755
+  git.latest:
+    - name: https://github.com/woodscloud/ops.git
+    - branch: master
+    - target: /opt/woodscloud-operations
+    - user: deploy
+    - unless: test -f /opt/woodscloud-operations/LOCKED

--- a/top.sls
+++ b/top.sls
@@ -1,0 +1,11 @@
+#   -------------------------------------------------------------
+#   Salt configuration for Woods Cloud servers
+#   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#   Project:        Woods Cloud
+#   Created:        2017-09-25
+#   License:        Trivial work, not eligible to copyright
+#   -------------------------------------------------------------
+
+base:
+  'local':
+    - roles/saltmaster/staging


### PR DESCRIPTION
Clone this repo to /opt/woodscloud-operations, that will be the base directory in Salt configuration.

Later, we'll clone from a Phab instance, to deploy from our infrastructure and not from a third party one.