### PR TITLE
Fix permissions for ops directory

### DIFF
--- a/roles/saltmaster/staging/init.sls
+++ b/roles/saltmaster/staging/init.sls
@@ -6,15 +6,24 @@
 #   License:        Trivial work, not eligible to copyright
 #   -------------------------------------------------------------
 
+staging_git_configuration:
+  git.config_set:
+    - user: deploy
+    - global: True
+    - name: core.sharedRepository
+    - value: group
+
 staging_repo:
   file.directory:
     - name: /opt/woodscloud-operations
     - user: deploy
     - group: deploy
-    - dir_mode: 755
+    - dir_mode: 775
   git.latest:
     - name: https://github.com/woodscloud/ops.git
     - branch: master
     - target: /opt/woodscloud-operations
     - user: deploy
     - unless: test -f /opt/woodscloud-operations/LOCKED
+    - require:
+      - git: staging_git_configuration


### PR DESCRIPTION
The group 'deploy' must have rights on the directory, so the the users
belonging to the deploy group can control the .git directory.