### PR TITLE
Consolidate a core role

### DIFF
--- a/roles/core/init.sls
+++ b/roles/core/init.sls
@@ -1,14 +1,12 @@
 #   -------------------------------------------------------------
-#   Salt configuration for Woods Cloud servers
+#   Salt — Units for every server
 #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #   Project:        Woods Cloud
-#   Created:        2017-09-25
 #   License:        Trivial work, not eligible to copyright
 #   -------------------------------------------------------------
 
-base:
-  '*':
-    - roles/core
-  'local':
-    - nodes
-    - roles/saltmaster
+include:
+  - ./hostname
+  - ./motd
+  - ./rsyslog
+  - ./sshd


### PR DESCRIPTION
Currently, there are several units in roles/core, included from top.sls.

Instead, we now define a role as a fixed set of units, and the top.sls
responsibility to include roles, not units.

If a server needs some particular units, they can include them directly
as exception, and if several servers need that, we can create a new role
including units from another one.