### PR TITLE
Grow a forest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Python
+*.pyc

--- a/_modules/forests.py
+++ b/_modules/forests.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+#   -------------------------------------------------------------
+#   Salt — Forests execution module
+#   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#   Project:        Woods Clouds
+#   Created:        2017-10-11
+#   Description:    Functions related to forests
+#   License:        BSD-2-Clause
+#   -------------------------------------------------------------
+
+
+def exists(forest):
+    '''
+    A function to check if a forest exists.
+
+    CLI Example::
+
+        salt '*' forests.exists evuaf
+    '''
+    return forest in __pillar__.get('forests', [])

--- a/_tests/Makefile
+++ b/_tests/Makefile
@@ -1,0 +1,3 @@
+test:
+	python -m unittest discover modules
+

--- a/_tests/mocks/dunden.py
+++ b/_tests/mocks/dunden.py
@@ -1,0 +1,2 @@
+def get(variable, default=None):
+    return default

--- a/_tests/modules/test_forests.py
+++ b/_tests/modules/test_forests.py
@@ -1,0 +1,24 @@
+import imp
+import unittest
+
+
+salt_test_case = imp.load_source('salt_test_case', "salt_test_case.py")
+forests = imp.load_source('forests', "../_modules/forests.py")
+
+
+class Testinstance(unittest.TestCase, salt_test_case.SaltTestCase):
+
+    def setUp(self):
+        self.instance = forests
+        self.mock_pillars()
+
+    def test_exists(self):
+        self.pillars['forests'] = ['evuaf', 'woodscloud']
+
+        with self.get_pillar_get_mock():
+            self.assertTrue(forests.exists('evuaf'))
+            self.assertFalse(forests.exists('notexisting'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/_tests/salt_test_case.py
+++ b/_tests/salt_test_case.py
@@ -1,0 +1,29 @@
+import imp
+from mock import patch
+
+
+class SaltTestCase:
+
+    pillars = {}
+
+    def mock_dunden(self):
+        return imp.load_source('__pillar__', "mocks/dunden.py")
+
+    def mock_pillars(self, target=None):
+        if not target:
+            target = self.instance
+
+        target.__pillar__ = self.mock_dunden()
+
+    def get_pillar_get_mock(self, target=None):
+        if not target:
+            target = self.instance
+
+        return patch.object(
+            target.__pillar__,
+            'get',
+            return_value=self.get_mocked_pillar_value('forests')
+        )
+
+    def get_mocked_pillar_value(self, pillar_name):
+        return self.pillars[pillar_name]

--- a/pillar/core/forests.sls
+++ b/pillar/core/forests.sls
@@ -1,0 +1,26 @@
+#   -------------------------------------------------------------
+#   Salt — Forests map
+#   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#   Project:        Woods Clouds
+#   Created:        2017-10-11
+#   Description:    Groups nodes by forest to allow to apply
+#                   a common configuration, like users/groups
+#                   to a set of nodes (ie servers).
+#   License:        Trivial work, not eligible to copyright
+#   -------------------------------------------------------------
+
+#   -------------------------------------------------------------
+#   Table of contents
+#   -------------------------------------------------------------
+#
+#   :: Forests
+#
+#   -------------------------------------------------------------
+
+#   -------------------------------------------------------------
+#   Forests
+#   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+forests:
+  - evuaf
+  - woodscloud

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,3 +1,4 @@
 base:
   '*':
+    - core.forests
     - core.hostnames


### PR DESCRIPTION
**Concept of forest**

The forest is defined as a set of nodes, ie a set of servers.

An example of forest is 'evuaf' for Evuaf nodes, another
one 'woodscloud' for our internal Woods Clouds nodes.

The goal of a forest is to allow to apply a configuration
to different nodes, like populate Evuaf user groups
only on Evuaf servers.

**Pillar**

A new pillar entry called `forests` is provided
to list the available forests.

The first forests defined will be for Evuaf
and Woods Cloud (for our own internal needs).

**Custom execution module**

Starting from this change, complex logic handling
will be stored in custom execution modules.

This change introduces the following Salt method:

forests.exists:

    A function to check if a forest exists.

    CLI Example::

        salt '*' forests.exists evuaf

In a state or a linter, it can be called to check if a
forest value is valid.

**Unit tests**

Salt provides code to test the internal modules in the salt
repository, but not for custom modules.

This change provides mocking capabilities for the dunden
dictionaries like __pillar__.

A makefile allows to run the test suite with `make test`.

**Git configuration**

The new Python code can produce .pyc compiled artefacts.
As such, files are ignored.